### PR TITLE
docs(readme): update readme nodejs examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,11 +30,9 @@ Need image reader dependence for node.js
 - Samsung Internet: 2.0+
 - ~~Internet Explorer~~
 
-
 ### Node
 
 - Node.js: 6.0+
-
 
 ## Install
 
@@ -44,7 +42,6 @@ Need image reader dependence for node.js
 npm install --save extract-colors
 ```
 
-
 ### For node.js
 
 Need to install an ImageData extractor like `get-pixels`
@@ -53,48 +50,70 @@ Need to install an ImageData extractor like `get-pixels`
 npm install --save extract-colors get-pixels
 ```
 
-
 ## Usage
 
 ### Browser example
 
 ```js
-import { extractColors } from 'extract-colors'
+import { extractColors } from 'extract-colors';
 
-const src = 'my-image.jpg'
+const src = 'my-image.jpg';
 
-extractColors(src)
-  .then(console.log)
-  .catch(console.error)
+extractColors(src).then(console.log).catch(console.error);
 ```
 
 > You can use different types for `src` param (`String` for a path of image, `HTMLImageElement` or `ImageData`).
 
-
-### Node.js example
+### Node.js example using `get-pixels`
 
 ```js
-const path = require('path')
-const getPixels = require("get-pixels")
-const { extractColors } = require('extract-colors')
+const path = require('path');
+const getPixels = require('get-pixels');
+const { extractColors } = require('extract-colors');
 
-const src = path.join(__dirname, './my-image.jpg')
+const src = path.join(__dirname, './my-image.jpg');
 
 getPixels(src, (err, pixels) => {
-  if(!err) {
-    const data = [...pixels.data]
-    const [width, height] = pixels.shape
+  if (!err) {
+    const data = [...pixels.data];
+    const [width, height] = pixels.shape;
 
-    extractColors({ data, width, height })
-      .then(console.log)
-      .catch(console.log)
+    extractColors({ data, width, height }).then(console.log).catch(console.log);
   }
-})
+});
 ```
 
 > This example use `get-pixels` but you can change the lib.
-> Just send and ImageData object to `extractColors(imageData)`.
+> Just send the ImageData object to `extractColors(imageData)`.
 
+### Node.js example using native `fetch`
+
+```ts
+import { type FinalColor } from 'extract-colors/lib/types/Color';
+import { extractColors } from 'extract-colors';
+
+// ...
+
+async function getImageColors(imgUrl: string): Promise<FinalColor[]> {
+  const width = 100; // optional
+  const height = 100; // optional
+  const options = {
+    /* ... */
+  };
+  try {
+    // Fetch image data from URL
+    const res = await fetch(imgUrl);
+    const blob = await res.arrayBuffer();
+    const buffer = Buffer.from(blob);
+    const img = Uint8ClampedArray.from(buffer);
+    const colors = await extractColors({ data: img, width, height }, options);
+    return colors;
+  } catch (e) {
+    console.error('Error extracting colors from image', e);
+    return [];
+  }
+}
+```
 
 ### ExtractorOptions
 
@@ -105,23 +124,21 @@ const options = {
   colorValidator: (red, green, blue, alpha = 255) => alpha > 250,
   saturationDistance: 0.2,
   lightnessDistance: 0.2,
-  hueDistance: 0.083333333
-}
+  hueDistance: 0.083333333,
+};
 
-extractColors(src, options)
-  .then(console.log)
-  .catch(console.error)
+extractColors(src, options).then(console.log).catch(console.error);
 ```
 
 **pixels**  
 _Total pixel number of the resized picture for calculation_  
 Type: `Integer`  
-Default: `64000`  
+Default: `64000`
 
 **distance**  
 _From 0 to 1 is the color distance to not have near colors (1 distance is between white and black)_  
 Type: `Number`  
-Default: `0.22`  
+Default: `0.22`
 
 **colorValidator**  
 _Test function to enable only some colors_  
@@ -149,7 +166,6 @@ _Minimum hue value between two colors otherwise the colors will be merged (from 
 Type: `String`  
 Default: `0.083333333`
 
-
 ## Return of the promise
 
 Array of colors with the followed properties:
@@ -171,22 +187,21 @@ Array of colors with the followed properties:
 ]
 ```
 
-| Field | Example | Type | Description |
-|---|---|---|---|
-| hex | #858409 | String | color in hexadecimal string |
-| red | 133 | Integer | red canal from 0 to 255 |
-| green | 132 | Integer | green canal from 0 to 255 |
-| blue | 9 | Integer | blue canal from 0 to 255 |
-| hue | 0.1653 | Number | color tone from 0 to 1 |
-| intensity | 0.4862 | Number | color intensity from 0 to 1 |
-| lightness | 0.2784 | Number | color lightness from 0 to 1 |
-| saturation | 0.8732 | Number | color saturation from 0 to 1 |
-| area | 0.0004 | Number | area of the color and his neighbouring colors from 0 to 1 |
-
+| Field      | Example | Type    | Description                                               |
+| ---------- | ------- | ------- | --------------------------------------------------------- |
+| hex        | #858409 | String  | color in hexadecimal string                               |
+| red        | 133     | Integer | red canal from 0 to 255                                   |
+| green      | 132     | Integer | green canal from 0 to 255                                 |
+| blue       | 9       | Integer | blue canal from 0 to 255                                  |
+| hue        | 0.1653  | Number  | color tone from 0 to 1                                    |
+| intensity  | 0.4862  | Number  | color intensity from 0 to 1                               |
+| lightness  | 0.2784  | Number  | color lightness from 0 to 1                               |
+| saturation | 0.8732  | Number  | color saturation from 0 to 1                              |
+| area       | 0.0004  | Number  | area of the color and his neighbouring colors from 0 to 1 |
 
 ## License
 
-Copyright (C) 2019  Damien Doussaud
+Copyright (C) 2019 Damien Doussaud
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -195,8 +210,8 @@ the Free Software Foundation, either version 3 of the License, or
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.

--- a/readme.md
+++ b/readme.md
@@ -97,38 +97,33 @@ import { type FinalColor } from 'extract-colors/lib/types/Color';
 import { extractColors } from 'extract-colors';
 import getPixels from 'get-pixels';
 
+type Pixels = {
+  data: Uint8Array;
+  shape: [number, number];
+};
 // ...
-async function getPixelsAsync(url: string) {
-    return new Promise(function (resolve, reject) {
-      getPixels(url, function (err, data) {
-        if (err !== null) reject(err);
-        else resolve(data);
-      });
-    });
-  }
 
+async function getPixelsAsync(url: string) {
+  return new Promise(function (resolve, reject) {
+    getPixels(url, function (err, data) {
+      if (err !== null) reject(err);
+      else resolve(data as Pixels);
+    });
+  });
+}
 
 async function getImageColors(imgUrl: string) {
   const options = {
     /* ... */
   };
   try {
-    const pixels = (await getPixelsAsync(imgUrl)) as {
-        data: Uint8Array;
-        shape: [number, number];
-      };
-      if (!pixels) return undefined;
+    const pixels = await getPixelsAsync(imgUrl);
+    if (!pixels) return [];
 
-      const data = [...pixels.data];
-      const [width, height] = pixels.shape;
-      const options {
-        /* config options */
-      }
-      const colors = await extractColors(
-        { data, width, height },
-        options
-      );
-      return colors;
+    const data = [...pixels.data];
+    const [width, height] = pixels.shape;
+    const colors = await extractColors({ data, width, height }, options);
+    return colors;
   } catch (e) {
     console.error('Error extracting colors from image', e);
     return [];

--- a/readme.md
+++ b/readme.md
@@ -86,28 +86,49 @@ getPixels(src, (err, pixels) => {
 > This example use `get-pixels` but you can change the lib.
 > Just send the ImageData object to `extractColors(imageData)`.
 
-### Node.js example using native `fetch`
+### Node.js example using Typescript and `get-pixels`
+
+```bash
+npm i -D @types/get-pixels
+```
 
 ```ts
 import { type FinalColor } from 'extract-colors/lib/types/Color';
 import { extractColors } from 'extract-colors';
+import getPixels from 'get-pixels';
 
 // ...
+async function getPixelsAsync(url: string) {
+    return new Promise(function (resolve, reject) {
+      getPixels(url, function (err, data) {
+        if (err !== null) reject(err);
+        else resolve(data);
+      });
+    });
+  }
 
-async function getImageColors(imgUrl: string): Promise<FinalColor[]> {
-  const width = 100; // optional
-  const height = 100; // optional
+
+async function getImageColors(imgUrl: string) {
   const options = {
     /* ... */
   };
   try {
-    // Fetch image data from URL
-    const res = await fetch(imgUrl);
-    const blob = await res.arrayBuffer();
-    const buffer = Buffer.from(blob);
-    const img = Uint8ClampedArray.from(buffer);
-    const colors = await extractColors({ data: img, width, height }, options);
-    return colors;
+    const pixels = (await getPixelsAsync(imgUrl)) as {
+        data: Uint8Array;
+        shape: [number, number];
+      };
+      if (!pixels) return undefined;
+
+      const data = [...pixels.data];
+      const [width, height] = pixels.shape;
+      const options {
+        /* config options */
+      }
+      const colors = await extractColors(
+        { data, width, height },
+        options
+      );
+      return colors;
   } catch (e) {
     console.error('Error extracting colors from image', e);
     return [];

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,6 @@ npm i -D @types/get-pixels
 ```
 
 ```ts
-import { type FinalColor } from 'extract-colors/lib/types/Color';
 import { extractColors } from 'extract-colors';
 import getPixels from 'get-pixels';
 


### PR DESCRIPTION
## Description

Update readme to include Node.js examples using typescript and get-pixels

## Reasoning

* took a while to piece all of it together
* both libs are easy to use and fast! 
* hopefully  

## Tests

* the code sample below was tested in a Next.js 14.x node env (21.x)
* works extremely fast inside server components
* Note: the existing `Browser Example` worked as expected in Next.js 14.x client components 

## Screenshots

![image](https://github.com/user-attachments/assets/ff96af34-3759-48cb-a344-0671ee21b589)

