### PR TITLE
use offscreenCanvas on supported devices

### DIFF
--- a/src/extractColors.ts
+++ b/src/extractColors.ts
@@ -65,9 +65,11 @@ const _getImageData = (_image: HTMLImageElement, _pixels: number) => {
     currentPixels < _pixels
       ? _image.height
       : Math.round(_image.height * Math.sqrt(_pixels / currentPixels));
-
-  const supportsOffscreenCanvas = ;
-  const canvas = !("OffscreenCanvas" in window) ? document.createElement("canvas") : new OffscreenCanvas();
+  const canvas = 
+    !("OffscreenCanvas" in window)
+      ? document.createElement("canvas")
+      : new OffscreenCanvas();
+  
   canvas.width = width;
   canvas.height = height;
 

--- a/src/extractColors.ts
+++ b/src/extractColors.ts
@@ -66,7 +66,8 @@ const _getImageData = (_image: HTMLImageElement, _pixels: number) => {
       ? _image.height
       : Math.round(_image.height * Math.sqrt(_pixels / currentPixels));
 
-  const canvas = document.createElement("canvas");
+  const supportsOffscreenCanvas = ;
+  const canvas = !("OffscreenCanvas" in window) ? document.createElement("canvas") : new OffscreenCanvas();
   canvas.width = width;
   canvas.height = height;
 


### PR DESCRIPTION
- https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas
- https://web.dev/articles/offscreen-canvas
- https://caniuse.com/offscreencanvas

I want to use `extract-colors` in my project to get more accurate colors, and it requires some high performance. 
The solution I have proposed is already being used here https://github.com/n-ce/ytify/blob/de58/src/scripts/theme.ts#L5-L7.